### PR TITLE
Update CLOSURE_BASE_PATH so asserts don't fail on Windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ COMPILED = false;
 
 var path = require('path');
 var closureBasePath = path.join(__dirname, 'closure/goog/');
-var goog = require('closure').Closure({CLOSURE_BASE_PATH: closureBasePath + '/'});
+var goog = require('closure').Closure({CLOSURE_BASE_PATH: closureBasePath});
 
 goog.require('goog.array');
 goog.require('goog.proto2.PbLiteSerializer');


### PR DESCRIPTION
Running this lib on Windows fails with this error:

AssertionError: CLOSURE_BASE_PATH must end with '\'

it happens because of this commit: https://github.com/hansmalherbe/node-closure/commit/d30a5e822f95373b735c021bf11095184780f050

Removing the trailing '/' fixed it!
